### PR TITLE
Convert extension definitions to RDF in a deterministic order.

### DIFF
--- a/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFSerialiser.java
+++ b/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFSerialiser.java
@@ -19,6 +19,7 @@
 package org.incenp.obofoundry.sssom.rdf;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -287,7 +288,11 @@ public class RDFSerialiser {
                 return null;
             }
 
-            for ( ExtensionDefinition ed : values ) {
+            ArrayList<ExtensionDefinition> sorted = new ArrayList<ExtensionDefinition>();
+            sorted.addAll(values);
+            sorted.sort((a, b) -> a.getProperty().compareTo(b.getProperty()));
+
+            for ( ExtensionDefinition ed : sorted ) {
                 BNode edNode = Values.bnode();
                 // FIXME: The SSSOM spec does not say how extension definitions should be
                 // serialised in RDF.

--- a/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFSerialiser.java
+++ b/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFSerialiser.java
@@ -19,7 +19,6 @@
 package org.incenp.obofoundry.sssom.rdf;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,7 @@ import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.incenp.obofoundry.sssom.DefaultMappingComparator;
 import org.incenp.obofoundry.sssom.ExtraMetadataPolicy;
 import org.incenp.obofoundry.sssom.PrefixManager;
 import org.incenp.obofoundry.sssom.Slot;
@@ -150,6 +150,7 @@ public class RDFSerialiser {
         SlotHelper.getMappingSetHelper().visitSlots(ms, setVisitor);
 
         RDFSlotVisitor<Mapping> mappingVisitor = new RDFSlotVisitor<Mapping>(model, null, prefixManager, usedPrefixes);
+        ms.getMappings().sort(new DefaultMappingComparator());
         for ( Mapping mapping : ms.getMappings() ) {
             // Add individual mapping
             BNode mappingNode = Values.bnode();
@@ -288,11 +289,8 @@ public class RDFSerialiser {
                 return null;
             }
 
-            ArrayList<ExtensionDefinition> sorted = new ArrayList<ExtensionDefinition>();
-            sorted.addAll(values);
-            sorted.sort((a, b) -> a.getProperty().compareTo(b.getProperty()));
-
-            for ( ExtensionDefinition ed : sorted ) {
+            values.sort((a, b) -> a.getProperty().compareTo(b.getProperty()));
+            for ( ExtensionDefinition ed : values ) {
                 BNode edNode = Values.bnode();
                 // FIXME: The SSSOM spec does not say how extension definitions should be
                 // serialised in RDF.

--- a/ext/src/test/java/org/incenp/obofoundry/sssom/rdf/RDFWriterTest.java
+++ b/ext/src/test/java/org/incenp/obofoundry/sssom/rdf/RDFWriterTest.java
@@ -49,17 +49,33 @@ public class RDFWriterTest {
     }
 
     @Test
-    void testWriteNonStandardMetadata() throws SSSOMFormatException, IOException {
+    void testWriteNoStandardMetadata() throws SSSOMFormatException, IOException {
+        TSVReader reader = new TSVReader("../core/src/test/resources/sets/exo2c-with-extensions.sssom.tsv");
+        reader.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED);
+        MappingSet ms = reader.read();
+
+        assertWrittenAsExpected(ms, "test-ttl-output-extensions-none", null,
+                (w) -> w.setExtraMetadataPolicy(ExtraMetadataPolicy.NONE));
+    }
+
+    @Test
+    void testWriteDefinedNonStandardMetadata() throws SSSOMFormatException, IOException {
         TSVReader reader = new TSVReader("../core/src/test/resources/sets/exo2c-with-extensions.sssom.tsv");
         reader.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED);
         MappingSet ms = reader.read();
 
         assertWrittenAsExpected(ms, "test-ttl-output-extensions-defined", null,
                 (w) -> w.setExtraMetadataPolicy(ExtraMetadataPolicy.DEFINED));
+    }
+
+    @Test
+    void testWriteUnDefinedNonStandardMetadata() throws SSSOMFormatException, IOException {
+        TSVReader reader = new TSVReader("../core/src/test/resources/sets/exo2c-with-extensions.sssom.tsv");
+        reader.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED);
+        MappingSet ms = reader.read();
+
         assertWrittenAsExpected(ms, "test-ttl-output-extensions-undefined", null,
                 (w) -> w.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED));
-        assertWrittenAsExpected(ms, "test-ttl-output-extensions-none", null,
-                (w) -> w.setExtraMetadataPolicy(ExtraMetadataPolicy.NONE));
     }
 
     private void assertWrittenAsExpected(MappingSet ms, String expectedBasename, String actualBasename,

--- a/ext/src/test/resources/output/test-ttl-output-extensions-defined.ttl
+++ b/ext/src/test/resources/output/test-ttl-output-extensions-defined.ttl
@@ -19,10 +19,6 @@
   <http://sssom.invalid/ext_undeclared_foo> "Foo B";
   EXPROP:fooProperty "Foo A";
   sssom:extension_definitions [
-      sssom:property EXPROP:fooProperty;
-      sssom:slot_name "ext_foo";
-      sssom:type_hint xsd:string
-    ], [
       sssom:property <http://sssom.invalid/ext_undeclared_baz>;
       sssom:slot_name "ext_undeclared_baz";
       sssom:type_hint xsd:string
@@ -38,6 +34,10 @@
       sssom:property EXPROP:bazProperty;
       sssom:slot_name "ext_baz";
       sssom:type_hint linkml:Uriorcurie
+    ], [
+      sssom:property EXPROP:fooProperty;
+      sssom:slot_name "ext_foo";
+      sssom:type_hint xsd:string
     ];
   sssom:mapping_set_id "https://example.org/sets/exo2c-with-extensions"^^xsd:anyURI;
   sssom:mappings [ a owl:Axiom;

--- a/ext/src/test/resources/output/test-ttl-output-extensions-undefined.ttl
+++ b/ext/src/test/resources/output/test-ttl-output-extensions-undefined.ttl
@@ -19,44 +19,6 @@
   EXPROP:fooProperty "Foo A";
   sssom:mapping_set_id "https://example.org/sets/exo2c-with-extensions"^^xsd:anyURI;
   sssom:mappings [ a owl:Axiom;
-      <http://sssom.invalid/ext_undeclared_baz> "BAZ A";
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0001;
-      owl:annotatedTarget COMENT:0011;
-      EXPROP:barProperty "111"^^xsd:int;
-      EXPROP:bazProperty ORGENT:BAZ_0001;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "alpha";
-      sssom:subject_label "alice"
-    ], [ a owl:Axiom;
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0002;
-      owl:annotatedTarget COMENT:0012;
-      EXPROP:barProperty "112"^^xsd:int;
-      EXPROP:bazProperty ORGENT:BAZ_0002;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "beta";
-      sssom:subject_label "bob"
-    ], [ a owl:Axiom;
-      <http://sssom.invalid/ext_undeclared_baz> "Baz C";
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0004;
-      owl:annotatedTarget COMENT:0014;
-      EXPROP:barProperty "114"^^xsd:int;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "delta";
-      sssom:subject_label "daphne"
-    ], [ a owl:Axiom;
-      <http://sssom.invalid/ext_undeclared_baz> "Baz E";
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0005;
-      owl:annotatedTarget COMENT:0015;
-      EXPROP:barProperty "115"^^xsd:int;
-      EXPROP:bazProperty ORGENT:BAZ_0005;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "epsilon";
-      sssom:subject_label "eve"
-    ], [ a owl:Axiom;
       <http://sssom.invalid/ext_undeclared_baz> "Baz F";
       owl:annotatedProperty skos:closeMatch;
       owl:annotatedSource ORGENT:0006;
@@ -96,4 +58,42 @@
       sssom:mapping_justification semapv:ManualMappingCuration;
       sssom:object_label "iota";
       sssom:subject_label "ivan"
+    ], [ a owl:Axiom;
+      <http://sssom.invalid/ext_undeclared_baz> "BAZ A";
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0001;
+      owl:annotatedTarget COMENT:0011;
+      EXPROP:barProperty "111"^^xsd:int;
+      EXPROP:bazProperty ORGENT:BAZ_0001;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "alpha";
+      sssom:subject_label "alice"
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0002;
+      owl:annotatedTarget COMENT:0012;
+      EXPROP:barProperty "112"^^xsd:int;
+      EXPROP:bazProperty ORGENT:BAZ_0002;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "beta";
+      sssom:subject_label "bob"
+    ], [ a owl:Axiom;
+      <http://sssom.invalid/ext_undeclared_baz> "Baz C";
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0004;
+      owl:annotatedTarget COMENT:0014;
+      EXPROP:barProperty "114"^^xsd:int;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "delta";
+      sssom:subject_label "daphne"
+    ], [ a owl:Axiom;
+      <http://sssom.invalid/ext_undeclared_baz> "Baz E";
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0005;
+      owl:annotatedTarget COMENT:0015;
+      EXPROP:barProperty "115"^^xsd:int;
+      EXPROP:bazProperty ORGENT:BAZ_0005;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "epsilon";
+      sssom:subject_label "eve"
     ] .

--- a/ext/src/test/resources/output/test-ttl-output.ttl
+++ b/ext/src/test/resources/output/test-ttl-output.ttl
@@ -17,6 +17,11 @@
   sssom:mapping_set_id "https://example.org/sets/exo2c"^^xsd:anyURI;
   sssom:mappings [ a owl:Axiom;
       owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource FBbt:12345678;
+      owl:annotatedTarget UBERON:1234567;
+      sssom:mapping_justification semapv:ManualMappingCuration
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
       owl:annotatedSource ORGENT:0001;
       owl:annotatedTarget COMENT:0011;
       sssom:mapping_justification semapv:ManualMappingCuration;
@@ -32,9 +37,4 @@
       sssom:object_label "beta";
       sssom:subject_label "bob";
       sssom:subject_type owl:Class
-    ], [ a owl:Axiom;
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource FBbt:12345678;
-      owl:annotatedTarget UBERON:1234567;
-      sssom:mapping_justification semapv:ManualMappingCuration
     ] .


### PR DESCRIPTION
The test to serialise extension definitions fail on GitHub, while it passes on my machine. Checking if we can serialise extension definitions in a defined order.