### PR TITLE
Fix reproducibility issue of RDF serialisation tests.

### DIFF
--- a/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFSerialiser.java
+++ b/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFSerialiser.java
@@ -33,6 +33,7 @@ import org.eclipse.rdf4j.model.impl.TreeModel;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.incenp.obofoundry.sssom.DefaultMappingComparator;
 import org.incenp.obofoundry.sssom.ExtraMetadataPolicy;
 import org.incenp.obofoundry.sssom.PrefixManager;
 import org.incenp.obofoundry.sssom.Slot;
@@ -51,6 +52,7 @@ import org.incenp.obofoundry.sssom.model.MappingSet;
 public class RDFSerialiser {
 
     private ExtraMetadataPolicy extraPolicy;
+    int bnodeCounter = 0;
 
     /**
      * Creates a new instance with the default policy for serialising non-standard
@@ -141,7 +143,7 @@ public class RDFSerialiser {
         Set<String> usedPrefixes = prefixManager != null ? new HashSet<String>() : null;
 
         // Create the mapping set node
-        BNode set = Values.bnode();
+        BNode set = Values.bnode(String.valueOf(bnodeCounter++));
         model.add(set, RDF.TYPE, Constants.SSSOM_MAPPING_SET);
 
         // Add the set-level metadata
@@ -149,9 +151,10 @@ public class RDFSerialiser {
         SlotHelper.getMappingSetHelper().visitSlots(ms, setVisitor);
 
         RDFSlotVisitor<Mapping> mappingVisitor = new RDFSlotVisitor<Mapping>(model, null, prefixManager, usedPrefixes);
+        ms.getMappings().sort(new DefaultMappingComparator());
         for ( Mapping mapping : ms.getMappings() ) {
             // Add individual mapping
-            BNode mappingNode = Values.bnode();
+            BNode mappingNode = Values.bnode(String.valueOf(bnodeCounter++));
             model.add(mappingNode, RDF.TYPE, Constants.OWL_AXIOM);
             model.add(set, Constants.SSSOM_MAPPINGS, mappingNode);
 
@@ -287,8 +290,9 @@ public class RDFSerialiser {
                 return null;
             }
 
+            values.sort((a, b) -> a.getProperty().compareTo(b.getProperty()));
             for ( ExtensionDefinition ed : values ) {
-                BNode edNode = Values.bnode();
+                BNode edNode = Values.bnode(String.valueOf(bnodeCounter++));
                 // FIXME: The SSSOM spec does not say how extension definitions should be
                 // serialised in RDF.
                 model.add(edNode, Constants.SSSOM_EXT_PROPERTY, Values.iri(ed.getProperty()));

--- a/ext/src/test/java/org/incenp/obofoundry/sssom/rdf/RDFWriterTest.java
+++ b/ext/src/test/java/org/incenp/obofoundry/sssom/rdf/RDFWriterTest.java
@@ -49,15 +49,31 @@ public class RDFWriterTest {
     }
 
     @Test
-    void testWriteNonStandardMetadata() throws SSSOMFormatException, IOException {
+    void testWriteDefinedNonStandardMetadata() throws SSSOMFormatException, IOException {
         TSVReader reader = new TSVReader("../core/src/test/resources/sets/exo2c-with-extensions.sssom.tsv");
         reader.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED);
         MappingSet ms = reader.read();
 
         assertWrittenAsExpected(ms, "test-ttl-output-extensions-defined", null,
                 (w) -> w.setExtraMetadataPolicy(ExtraMetadataPolicy.DEFINED));
+    }
+
+    @Test
+    void testWriteUndefinedNonStandardMetadata() throws SSSOMFormatException, IOException {
+        TSVReader reader = new TSVReader("../core/src/test/resources/sets/exo2c-with-extensions.sssom.tsv");
+        reader.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED);
+        MappingSet ms = reader.read();
+
         assertWrittenAsExpected(ms, "test-ttl-output-extensions-undefined", null,
                 (w) -> w.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED));
+    }
+
+    @Test
+    void testWriteNoNonStandardMetadata() throws SSSOMFormatException, IOException {
+        TSVReader reader = new TSVReader("../core/src/test/resources/sets/exo2c-with-extensions.sssom.tsv");
+        reader.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED);
+        MappingSet ms = reader.read();
+
         assertWrittenAsExpected(ms, "test-ttl-output-extensions-none", null,
                 (w) -> w.setExtraMetadataPolicy(ExtraMetadataPolicy.NONE));
     }

--- a/ext/src/test/resources/output/test-ttl-output-extensions-defined.ttl
+++ b/ext/src/test/resources/output/test-ttl-output-extensions-defined.ttl
@@ -19,10 +19,6 @@
   <http://sssom.invalid/ext_undeclared_foo> "Foo B";
   EXPROP:fooProperty "Foo A";
   sssom:extension_definitions [
-      sssom:property EXPROP:fooProperty;
-      sssom:slot_name "ext_foo";
-      sssom:type_hint xsd:string
-    ], [
       sssom:property <http://sssom.invalid/ext_undeclared_baz>;
       sssom:slot_name "ext_undeclared_baz";
       sssom:type_hint xsd:string
@@ -38,47 +34,13 @@
       sssom:property EXPROP:bazProperty;
       sssom:slot_name "ext_baz";
       sssom:type_hint linkml:Uriorcurie
+    ], [
+      sssom:property EXPROP:fooProperty;
+      sssom:slot_name "ext_foo";
+      sssom:type_hint xsd:string
     ];
   sssom:mapping_set_id "https://example.org/sets/exo2c-with-extensions"^^xsd:anyURI;
   sssom:mappings [ a owl:Axiom;
-      <http://sssom.invalid/ext_undeclared_baz> "BAZ A";
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0001;
-      owl:annotatedTarget COMENT:0011;
-      EXPROP:barProperty "111"^^xsd:int;
-      EXPROP:bazProperty ORGENT:BAZ_0001;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "alpha";
-      sssom:subject_label "alice"
-    ], [ a owl:Axiom;
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0002;
-      owl:annotatedTarget COMENT:0012;
-      EXPROP:barProperty "112"^^xsd:int;
-      EXPROP:bazProperty ORGENT:BAZ_0002;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "beta";
-      sssom:subject_label "bob"
-    ], [ a owl:Axiom;
-      <http://sssom.invalid/ext_undeclared_baz> "Baz C";
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0004;
-      owl:annotatedTarget COMENT:0014;
-      EXPROP:barProperty "114"^^xsd:int;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "delta";
-      sssom:subject_label "daphne"
-    ], [ a owl:Axiom;
-      <http://sssom.invalid/ext_undeclared_baz> "Baz E";
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource ORGENT:0005;
-      owl:annotatedTarget COMENT:0015;
-      EXPROP:barProperty "115"^^xsd:int;
-      EXPROP:bazProperty ORGENT:BAZ_0005;
-      sssom:mapping_justification semapv:ManualMappingCuration;
-      sssom:object_label "epsilon";
-      sssom:subject_label "eve"
-    ], [ a owl:Axiom;
       <http://sssom.invalid/ext_undeclared_baz> "Baz F";
       owl:annotatedProperty skos:closeMatch;
       owl:annotatedSource ORGENT:0006;
@@ -118,4 +80,42 @@
       sssom:mapping_justification semapv:ManualMappingCuration;
       sssom:object_label "iota";
       sssom:subject_label "ivan"
+    ], [ a owl:Axiom;
+      <http://sssom.invalid/ext_undeclared_baz> "BAZ A";
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0001;
+      owl:annotatedTarget COMENT:0011;
+      EXPROP:barProperty "111"^^xsd:int;
+      EXPROP:bazProperty ORGENT:BAZ_0001;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "alpha";
+      sssom:subject_label "alice"
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0002;
+      owl:annotatedTarget COMENT:0012;
+      EXPROP:barProperty "112"^^xsd:int;
+      EXPROP:bazProperty ORGENT:BAZ_0002;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "beta";
+      sssom:subject_label "bob"
+    ], [ a owl:Axiom;
+      <http://sssom.invalid/ext_undeclared_baz> "Baz C";
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0004;
+      owl:annotatedTarget COMENT:0014;
+      EXPROP:barProperty "114"^^xsd:int;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "delta";
+      sssom:subject_label "daphne"
+    ], [ a owl:Axiom;
+      <http://sssom.invalid/ext_undeclared_baz> "Baz E";
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0005;
+      owl:annotatedTarget COMENT:0015;
+      EXPROP:barProperty "115"^^xsd:int;
+      EXPROP:bazProperty ORGENT:BAZ_0005;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "epsilon";
+      sssom:subject_label "eve"
     ] .

--- a/ext/src/test/resources/output/test-ttl-output.ttl
+++ b/ext/src/test/resources/output/test-ttl-output.ttl
@@ -17,6 +17,11 @@
   sssom:mapping_set_id "https://example.org/sets/exo2c"^^xsd:anyURI;
   sssom:mappings [ a owl:Axiom;
       owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource FBbt:12345678;
+      owl:annotatedTarget UBERON:1234567;
+      sssom:mapping_justification semapv:ManualMappingCuration
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
       owl:annotatedSource ORGENT:0001;
       owl:annotatedTarget COMENT:0011;
       sssom:mapping_justification semapv:ManualMappingCuration;
@@ -32,9 +37,4 @@
       sssom:object_label "beta";
       sssom:subject_label "bob";
       sssom:subject_type owl:Class
-    ], [ a owl:Axiom;
-      owl:annotatedProperty skos:closeMatch;
-      owl:annotatedSource FBbt:12345678;
-      owl:annotatedTarget UBERON:1234567;
-      sssom:mapping_justification semapv:ManualMappingCuration
     ] .


### PR DESCRIPTION
Make sure that:
* all mappings are sorted prior to serialisation (as with the SSSOM/TSV serialiser);
* all extension definitions, if they are included (DEFINED policy), are sorted as well;
* blank nodes use IDs that are picked serially.

This is to ensure that RDF triples are written in a predictable and reproducible manner.