### PR TITLE
Add support for `sssom_version`

### DIFF
--- a/core/src/main/java/org/incenp/obofoundry/sssom/JSONWriter.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/JSONWriter.java
@@ -36,6 +36,7 @@ import org.incenp.obofoundry.sssom.model.ExtensionValue;
 import org.incenp.obofoundry.sssom.model.Mapping;
 import org.incenp.obofoundry.sssom.model.MappingSet;
 import org.incenp.obofoundry.sssom.model.ValueType;
+import org.incenp.obofoundry.sssom.model.Version;
 import org.incenp.obofoundry.sssom.slots.CurieMapSlot;
 import org.incenp.obofoundry.sssom.slots.DateSlot;
 import org.incenp.obofoundry.sssom.slots.DoubleSlot;
@@ -47,6 +48,7 @@ import org.incenp.obofoundry.sssom.slots.SlotHelper;
 import org.incenp.obofoundry.sssom.slots.SlotPropagator;
 import org.incenp.obofoundry.sssom.slots.SlotVisitorBase;
 import org.incenp.obofoundry.sssom.slots.StringSlot;
+import org.incenp.obofoundry.sssom.slots.VersionSlot;
 
 /**
  * A writer to serialise a SSSOM mapping set into a JSON format.
@@ -133,6 +135,9 @@ public class JSONWriter extends SSSOMWriter {
     protected void doWrite(MappingSet mappingSet) throws IOException {
         // Condense the set
         Set<String> condensedSlots = new SlotPropagator(condensationPolicy).condense(mappingSet, true);
+
+        // Determine minimum compliant version
+        mappingSet.setSssomVersion(new Validator().getCompliantVersion(mappingSet));
 
         startDict();
 
@@ -345,6 +350,14 @@ public class JSONWriter extends SSSOMWriter {
         @Override
         public void visit(CurieMapSlot<T> slot, T object, Map<String, String> curieMap) {
             // Nothing to do, we wrote the Curie map (if needed) already
+        }
+
+        @Override
+        public void visit(VersionSlot<T> slot, T object, Version value) {
+            if ( value != Version.SSSOM_1_0 && value != Version.UNKNOWN ) {
+                addKey(slot.getName());
+                addValue(value.toString());
+            }
         }
 
         @Override

--- a/core/src/main/java/org/incenp/obofoundry/sssom/TSVReader.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/TSVReader.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import org.incenp.obofoundry.sssom.model.BuiltinPrefix;
 import org.incenp.obofoundry.sssom.model.Mapping;
 import org.incenp.obofoundry.sssom.model.MappingSet;
+import org.incenp.obofoundry.sssom.model.Version;
 import org.incenp.obofoundry.sssom.slots.SlotPropagator;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -351,7 +352,7 @@ public class TSVReader extends SSSOMReader {
             while ( it.hasNext() ) {
                 try {
                     Map<String, Object> rawMapping = it.next();
-                    mappings.add(converter.convertMapping(rawMapping));
+                    mappings.add(converter.convertMapping(rawMapping, ms.getSssomVersion()));
                 } catch ( RuntimeJsonMappingException e ) {
                     throw new SSSOMFormatException("Error when parsing TSV table", e);
                 }
@@ -564,6 +565,7 @@ public class TSVReader extends SSSOMReader {
             reader.close();
         } else {
             ms = new MappingSet();
+            ms.setSssomVersion(Version.SSSOM_1_0);
             ms.setCurieMap(new HashMap<>());
         }
 

--- a/core/src/main/java/org/incenp/obofoundry/sssom/TSVWriter.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/TSVWriter.java
@@ -41,6 +41,7 @@ import org.incenp.obofoundry.sssom.model.ExtensionValue;
 import org.incenp.obofoundry.sssom.model.Mapping;
 import org.incenp.obofoundry.sssom.model.MappingSet;
 import org.incenp.obofoundry.sssom.model.ValueType;
+import org.incenp.obofoundry.sssom.model.Version;
 import org.incenp.obofoundry.sssom.slots.CurieMapSlot;
 import org.incenp.obofoundry.sssom.slots.DateSlot;
 import org.incenp.obofoundry.sssom.slots.DoubleSlot;
@@ -51,6 +52,7 @@ import org.incenp.obofoundry.sssom.slots.Slot;
 import org.incenp.obofoundry.sssom.slots.SlotHelper;
 import org.incenp.obofoundry.sssom.slots.SlotVisitorBase;
 import org.incenp.obofoundry.sssom.slots.StringSlot;
+import org.incenp.obofoundry.sssom.slots.VersionSlot;
 
 /**
  * A writer to serialise a SSSOM mapping set into the TSV format.
@@ -180,6 +182,9 @@ public class TSVWriter extends SSSOMWriter {
 
         // Condense the set
         Set<String> condensedSlots = condenseSet(mappingSet);
+
+        // Determine minimum compliant version
+        mappingSet.setSssomVersion(new Validator().getCompliantVersion(mappingSet));
 
         // Write the metadata
         MappingSetSlotVisitor v = new MappingSetSlotVisitor(metaWriter == null ? "#" : "");
@@ -396,6 +401,15 @@ public class TSVWriter extends SSSOMWriter {
                         sb.append("\n");
                     }
                 }
+            }
+        }
+
+        public void visit(VersionSlot<MappingSet> slot, MappingSet set, Version value) {
+            if ( value != Version.SSSOM_1_0 && value != Version.UNKNOWN ) {
+                sb.append(linePrefix);
+                sb.append("sssom_version: \"");
+                sb.append(value.toString());
+                sb.append("\"\n");
             }
         }
 

--- a/core/src/main/java/org/incenp/obofoundry/sssom/Validator.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/Validator.java
@@ -18,8 +18,18 @@
 
 package org.incenp.obofoundry.sssom;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.incenp.obofoundry.sssom.model.EntityType;
 import org.incenp.obofoundry.sssom.model.Mapping;
+import org.incenp.obofoundry.sssom.model.MappingSet;
+import org.incenp.obofoundry.sssom.model.Version;
+import org.incenp.obofoundry.sssom.slots.EntityTypeSlot;
+import org.incenp.obofoundry.sssom.slots.Slot;
+import org.incenp.obofoundry.sssom.slots.SlotHelper;
+import org.incenp.obofoundry.sssom.slots.SlotVisitorBase;
+import org.incenp.obofoundry.sssom.slots.VersionSlot;
 
 /**
  * Helper class to validate MappingSet and Mapping objects.
@@ -82,5 +92,77 @@ public class Validator {
         }
 
         return null;
+    }
+
+    /**
+     * Gets the minimum version of the SSSOM specification that the given set is
+     * compliant with.
+     * <p>
+     * FIXME: This does not really have anything to do with “validation”, so this
+     * class may not be the best place for such a method.
+     * 
+     * @param set The set whose compliance is to be checked.
+     * @return The earliest version of the SSSOM specification that defines all
+     *         slots and values required by the set.
+     */
+    public Version getCompliantVersion(MappingSet set) {
+        Set<Version> versions = new HashSet<>();
+
+        // Check minimal version required by set metadata
+        SlotHelper.getMappingSetHelper().visitSlots(set, new VersionVisitor<MappingSet>(versions), false);
+        Version highest = Version.getHighestVersion(versions);
+        if ( highest == Version.SSSOM_1_1 || set.getMappings() == null ) {
+            return highest;
+        }
+
+        // Then check the mappings themselves. If one mapping requires the highest
+        // supported version, then we can stop immediately, no need to loop over the
+        // entire set.
+        int nMappings = set.getMappings().size();
+        int i = 0;
+        VersionVisitor<Mapping> v = new VersionVisitor<>(versions);
+        while ( i < nMappings && highest != Version.SSSOM_1_1 ) {
+            SlotHelper.getMappingHelper().visitSlots(set.getMappings().get(i++), v, false);
+            highest = Version.getHighestVersion(versions);
+        }
+
+        return highest;
+    }
+
+    /*
+     * Helper class to visit all the slots in a mapping set or a mapping and collect
+     * the minimum required SSSOM version.
+     */
+    private class VersionVisitor<T> extends SlotVisitorBase<T> {
+        Set<Version> versions;
+
+        VersionVisitor(Set<Version> versions) {
+            this.versions = versions;
+        }
+
+        @Override
+        public void visit(Slot<T> slot, T object, Object value) {
+            // For almost all slots, all we need to do is to use directly the version the
+            // slot itself declares to be needing
+            versions.add(slot.getCompliantVersion());
+        }
+
+        @Override
+        public void visit(EntityTypeSlot<T> slot, T object, EntityType value) {
+            Version slotVersion = slot.getCompliantVersion();
+            if ( slotVersion == Version.SSSOM_1_0 && value == EntityType.COMPOSED_ENTITY_EXPRESSION ) {
+                // Even if the slot itself is compliant with 1.0, the "composed entity
+                // expression" value was added in 1.1
+                slotVersion = Version.SSSOM_1_1;
+            }
+            versions.add(slotVersion);
+        }
+
+        @Override
+        public void visit(VersionSlot<T> slot, T object, Version value) {
+            // Ignore the sssom_version slot, so that we do not consider a set as requiring
+            // SSSOM 1.1 just because it has a sssom_version slot
+        }
+
     }
 }

--- a/core/src/main/java/org/incenp/obofoundry/sssom/YAMLConverter.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/YAMLConverter.java
@@ -158,6 +158,7 @@ public class YAMLConverter {
         if ( rawVersion != null ) {
             if ( String.class.isInstance(rawVersion) ) {
                 version = Version.fromString(String.class.cast(rawVersion));
+                rawMap.remove("sssom_version");
             } else {
                 throw getTypingError("sssom_version");
             }

--- a/core/src/main/java/org/incenp/obofoundry/sssom/model/Version.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/model/Version.java
@@ -1,0 +1,113 @@
+/*
+ * SSSOM-Java - SSSOM library for Java
+ * Copyright © 2025 Damien Goutte-Gattat
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the Gnu General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.incenp.obofoundry.sssom.model;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * Represents a version of the SSSOM specification.
+ */
+public enum Version {
+
+    /**
+     * SSSOM specification version 1.0.
+     */
+    SSSOM_1_0(1, 0),
+
+    /**
+     * SSSOM specification version 1.1.
+     */
+    SSSOM_1_1(1, 1),
+
+    /**
+     * Represents an unrecognised version of the specification (possibly, a version
+     * more recent than the latest supported by this implementation).
+     */
+    UNKNOWN(0, 0);
+
+    private final int major;
+    private final int minor;
+
+    Version(int major, int minor) {
+        this.major = major;
+        this.minor = minor;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d", major, minor);
+    }
+
+    /**
+     * Checks whether this version is compatible with the indicated version.
+     * <p>
+     * For the purpose of this method, a version <em>A</em> is said to be compatible
+     * with another version <em>B</em> if an implementation compliant with
+     * <em>B</em> can accept data compliant with <em>A</em>. This is case iff: (1)
+     * both <em>A</em> and <em>B</em> have the same major version number, and (2)
+     * <em>A</em>’s minor version number is at most as high as <em>B</em>’s.
+     * <p>
+     * For example, version 1.0 is compatible with version 1.1; version 1.2 is
+     * <em>not</em> compatible with version 1.1.
+     * 
+     * @param target The version to compare to.
+     * @return {@code True} if this version is compatible with the target version,
+     *         {@code false} otherwise.
+     */
+    public boolean isCompatibleWith(Version target) {
+        return (major == target.major) && (minor <= target.minor);
+    }
+
+    /**
+     * Gets the most recent version of all the versions in the given collection.
+     * 
+     * @param versions A collection of versions.
+     * @return The most recent version, or {@link #SSSOM_1_0} if the collection is
+     *         empty.
+     */
+    public static Version getHighestVersion(Collection<Version> versions) {
+        Version ret = Version.SSSOM_1_0;
+        for ( Version v : versions ) {
+            if ( v.compareTo(ret) > 0 ) {
+                ret = v;
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Parses a string into the corresponding SSSOM version object.
+     * 
+     * @param v The string to parse.
+     * @return The corresponding version, or {@code #UNKNOWN} if the string does not
+     *         match any recognised version.
+     */
+    @JsonCreator
+    public static Version fromString(String v) {
+        if ( v.equals("1.0") ) {
+            return SSSOM_1_0;
+        } else if ( v.equals("1.1") ) {
+            return SSSOM_1_1;
+        } else {
+            return UNKNOWN;
+        }
+    }
+}

--- a/core/src/main/java/org/incenp/obofoundry/sssom/model/Versionable.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/model/Versionable.java
@@ -1,0 +1,40 @@
+/*
+ * SSSOM-Java - SSSOM library for Java
+ * Copyright © 2025 Damien Goutte-Gattat
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the Gnu General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.incenp.obofoundry.sssom.model;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation to provide information about the version of the SSSOM
+ * specification a slot is compliant with.
+ */
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface Versionable {
+    /**
+     * The version of the specification in which the slot was first introduced.
+     * 
+     * @return The earliest SSSOM version this slot is compatible with.
+     */
+    Version addedIn();
+}

--- a/core/src/main/java/org/incenp/obofoundry/sssom/slots/ISlotVisitor.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/slots/ISlotVisitor.java
@@ -27,6 +27,7 @@ import org.incenp.obofoundry.sssom.model.ExtensionDefinition;
 import org.incenp.obofoundry.sssom.model.ExtensionValue;
 import org.incenp.obofoundry.sssom.model.MappingCardinality;
 import org.incenp.obofoundry.sssom.model.PredicateModifier;
+import org.incenp.obofoundry.sssom.model.Version;
 
 /**
  * A visitor interface to visit the different types of metadata slots of a SSSOM
@@ -147,6 +148,16 @@ public interface ISlotVisitor<T> {
      * @param value  The value of the slot.
      */
     public void visit(PredicateModifierSlot<T> slot, T object, PredicateModifier value);
+
+    /**
+     * Visits a slot that holds a SSSOM version value.
+     * 
+     * @param slot    The slot that is being visited.
+     * @param object  The object to which the slot is attached.
+     * @param version The value of the slot.
+     */
+    default public void visit(VersionSlot<T> slot, T object, Version version) {
+    }
 
     /**
      * Visits a slot that holds a curie map.

--- a/core/src/main/java/org/incenp/obofoundry/sssom/slots/Slot.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/slots/Slot.java
@@ -27,6 +27,8 @@ import org.incenp.obofoundry.sssom.model.EntityReference;
 import org.incenp.obofoundry.sssom.model.Propagatable;
 import org.incenp.obofoundry.sssom.model.SlotURI;
 import org.incenp.obofoundry.sssom.model.URI;
+import org.incenp.obofoundry.sssom.model.Version;
+import org.incenp.obofoundry.sssom.model.Versionable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -39,6 +41,7 @@ public class Slot<T> {
     private Field field;
     private String name;
     private boolean entity;
+    private Version addedIn;
 
     /**
      * Creates a new instance.
@@ -52,6 +55,9 @@ public class Slot<T> {
         name = jsonAnnotation != null ? jsonAnnotation.value() : field.getName();
 
         entity = field.isAnnotationPresent(EntityReference.class);
+
+        Versionable versionAnnotation = field.getDeclaredAnnotation(Versionable.class);
+        addedIn = versionAnnotation != null ? versionAnnotation.addedIn() : Version.SSSOM_1_0;
     }
 
     /**
@@ -108,6 +114,16 @@ public class Slot<T> {
      */
     public boolean isURI() {
         return field.isAnnotationPresent(URI.class);
+    }
+
+    /**
+     * Gets the earliest version of the SSSOM specification this slot is compatible
+     * with. This is the version in which the slot was first introduced.
+     * 
+     * @return The earliest compatible SSSOM version.
+     */
+    public Version getCompliantVersion() {
+        return addedIn;
     }
 
     /**

--- a/core/src/main/java/org/incenp/obofoundry/sssom/slots/SlotHelper.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/slots/SlotHelper.java
@@ -35,6 +35,7 @@ import org.incenp.obofoundry.sssom.model.MappingCardinality;
 import org.incenp.obofoundry.sssom.model.MappingSet;
 import org.incenp.obofoundry.sssom.model.PredicateModifier;
 import org.incenp.obofoundry.sssom.model.URI;
+import org.incenp.obofoundry.sssom.model.Version;
 
 /**
  * A class to facilitate the manipulation of SSSOM slots. This class is mostly
@@ -426,6 +427,8 @@ public class SlotHelper<T> {
             return new MappingCardinalitySlot<T>(field);
         } else if ( javaType.equals(PredicateModifier.class) ) {
             return new PredicateModifierSlot<T>(field);
+        } else if ( javaType.equals(Version.class) ) {
+            return new VersionSlot<T>(field);
         } else if ( javaType.equals(List.class) ) {
             if ( name.equals("extensionDefinitions") ) {
                 return new ExtensionDefinitionSlot<T>(field);

--- a/core/src/main/java/org/incenp/obofoundry/sssom/slots/SlotVisitorBase.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/slots/SlotVisitorBase.java
@@ -27,6 +27,7 @@ import org.incenp.obofoundry.sssom.model.ExtensionDefinition;
 import org.incenp.obofoundry.sssom.model.ExtensionValue;
 import org.incenp.obofoundry.sssom.model.MappingCardinality;
 import org.incenp.obofoundry.sssom.model.PredicateModifier;
+import org.incenp.obofoundry.sssom.model.Version;
 
 /**
  * A default implementation of the {@link ISlotVisitor} interface that does
@@ -94,6 +95,11 @@ public class SlotVisitorBase<T> implements ISlotVisitor<T> {
 
     @Override
     public void visit(PredicateModifierSlot<T> slot, T object, PredicateModifier value) {
+        visit((Slot<T>) slot, object, value);
+    }
+
+    @Override
+    public void visit(VersionSlot<T> slot, T object, Version value) {
         visit((Slot<T>) slot, object, value);
     }
 

--- a/core/src/main/java/org/incenp/obofoundry/sssom/slots/VersionSlot.java
+++ b/core/src/main/java/org/incenp/obofoundry/sssom/slots/VersionSlot.java
@@ -1,0 +1,64 @@
+/*
+ * SSSOM-Java - SSSOM library for Java
+ * Copyright © 2025 Damien Goutte-Gattat
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the Gnu General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.incenp.obofoundry.sssom.slots;
+
+import java.lang.reflect.Field;
+
+import org.incenp.obofoundry.sssom.model.Version;
+
+/**
+ * Represents a metadata slot that holds a SSSOM version.
+ * 
+ * @param <T> The type of SSSOM object the slot is associated with. Of note,
+ *            currently, only the MappingSet object is defined to have a slot of
+ *            that type.
+ */
+public class VersionSlot<T> extends Slot<T> {
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param field The Java field that store the slot's data in a SSSOM object.
+     */
+    VersionSlot(Field field) {
+        super(field);
+    }
+
+    @Override
+    public void accept(ISlotVisitor<T> visitor, T target, Object value) {
+        visitor.visit(this, target, (Version) value);
+    }
+
+    /**
+     * Parses a string value into a SSSOM version and assigns it to the slot for the
+     * given object.
+     * <p>
+     * If the string does not correspond to a recognised SSSOM version, the slot is
+     * assigned the special value {@link Version#UNKNOWN}.
+     */
+    @Override
+    public void setValue(T object, String value) {
+        Version version = null;
+        if ( value != null ) {
+            version = Version.fromString(value);
+        }
+        super.setValue(object, version);
+    }
+
+}

--- a/core/src/main/lombok/org/incenp/obofoundry/sssom/model/Mapping.java
+++ b/core/src/main/lombok/org/incenp/obofoundry/sssom/model/Mapping.java
@@ -105,6 +105,7 @@ public class Mapping  {
     private String objectSourceVersion;
 
     @JsonProperty("predicate_type")
+    @Versionable(addedIn = Version.SSSOM_1_1)
     private EntityType predicateType;
 
     @JsonProperty("mapping_provider")

--- a/core/src/main/lombok/org/incenp/obofoundry/sssom/model/MappingSet.java
+++ b/core/src/main/lombok/org/incenp/obofoundry/sssom/model/MappingSet.java
@@ -19,6 +19,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Data
 @EqualsAndHashCode(callSuper=false)
 public class MappingSet  {
+    @JsonProperty("sssom_version")
+    @Versionable(addedIn = Version.SSSOM_1_1)
+    private Version sssomVersion;
+
     @JsonProperty("curie_map")
     private Map<String,String> curieMap;
 
@@ -85,6 +89,7 @@ public class MappingSet  {
 
     @JsonProperty("predicate_type")
     @Propagatable
+    @Versionable(addedIn = Version.SSSOM_1_1)
     private EntityType predicateType;
 
     @JsonProperty("mapping_provider")

--- a/core/src/test/java/org/incenp/obofoundry/sssom/JSONWriterTest.java
+++ b/core/src/test/java/org/incenp/obofoundry/sssom/JSONWriterTest.java
@@ -104,6 +104,7 @@ public class JSONWriterTest {
     void testTSVAndJSONRoundtrips() throws IOException, SSSOMFormatException {
         TSVtoJSONtoTSVRoundtrip("exo2c", ExtraMetadataPolicy.NONE);
         TSVtoJSONtoTSVRoundtrip("test-extensions-defined", ExtraMetadataPolicy.DEFINED);
+        TSVtoJSONtoTSVRoundtrip("test-writing-sssom11-version", ExtraMetadataPolicy.NONE);
     }
 
     private void TSVtoJSONtoTSVRoundtrip(String tsvFilename, ExtraMetadataPolicy policy)

--- a/core/src/test/java/org/incenp/obofoundry/sssom/TSVReaderTest.java
+++ b/core/src/test/java/org/incenp/obofoundry/sssom/TSVReaderTest.java
@@ -687,6 +687,18 @@ public class TSVReaderTest {
     }
 
     @Test
+    void testSSSOM10Version() throws IOException, SSSOMFormatException {
+        TSVReader reader = new TSVReader("src/test/resources/sets/test-sssom10-with-version.sssom.tsv");
+        reader.setExtraMetadataPolicy(ExtraMetadataPolicy.UNDEFINED);
+        MappingSet ms = reader.read();
+
+        Assertions.assertEquals(Version.SSSOM_1_0, ms.getSssomVersion());
+        // sssom_version slot should not be treated as a set-level extension slot
+        Assertions.assertNull(ms.getExtensions());
+        Assertions.assertNull(ms.getExtensionDefinitions());
+    }
+
+    @Test
     void testSSSOM11Version() throws IOException, SSSOMFormatException {
         TSVReader reader = new TSVReader("src/test/resources/sets/test-sssom11-slots-with-version.sssom.tsv");
         MappingSet ms = reader.read();

--- a/core/src/test/java/org/incenp/obofoundry/sssom/TSVWriterTest.java
+++ b/core/src/test/java/org/incenp/obofoundry/sssom/TSVWriterTest.java
@@ -30,6 +30,7 @@ import org.incenp.obofoundry.sssom.model.ExtensionDefinition;
 import org.incenp.obofoundry.sssom.model.ExtensionValue;
 import org.incenp.obofoundry.sssom.model.Mapping;
 import org.incenp.obofoundry.sssom.model.MappingSet;
+import org.incenp.obofoundry.sssom.model.Version;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -376,6 +377,28 @@ public class TSVWriterTest {
         if ( same ) {
             written.delete();
         }
+    }
+
+    @Test
+    void testWritingSSSOMVersion() throws IOException, SSSOMFormatException {
+        MappingSet ms = getTestSet();
+
+        // sssom_version=1.0 should not be written
+        ms.setSssomVersion(Version.SSSOM_1_0);
+        assertWrittenAsExpected(ms, "exo2c-minimal", null, null, null);
+
+        // neither should sssom_version=1.1, if the set is in fact compliant with 1.0
+        ms.setSssomVersion(Version.SSSOM_1_1);
+        assertWrittenAsExpected(ms, "exo2c-minimal", null, null, null);
+
+        // neither should an unknown version
+        ms.setSssomVersion(Version.UNKNOWN);
+        assertWrittenAsExpected(ms, "exo2c-minimal", null, null, null);
+
+        // but adding a SSSOM 1.1 slot should cause the writer to forcefully set
+        // sssom_version=1.1
+        ms.getMappings().get(0).setSubjectType(EntityType.COMPOSED_ENTITY_EXPRESSION);
+        assertWrittenAsExpected(ms, "test-writing-sssom11-version", null, null, null);
     }
 
     /*

--- a/core/src/test/java/org/incenp/obofoundry/sssom/model/VersionTest.java
+++ b/core/src/test/java/org/incenp/obofoundry/sssom/model/VersionTest.java
@@ -1,0 +1,60 @@
+/*
+ * SSSOM-Java - SSSOM library for Java
+ * Copyright © 2025 Damien Goutte-Gattat
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the Gnu General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.incenp.obofoundry.sssom.model;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VersionTest {
+
+    @Test
+    void testVersionCompatibility() {
+        Assertions.assertTrue(Version.SSSOM_1_0.isCompatibleWith(Version.SSSOM_1_0));
+        Assertions.assertTrue(Version.SSSOM_1_0.isCompatibleWith(Version.SSSOM_1_1));
+        Assertions.assertFalse(Version.SSSOM_1_1.isCompatibleWith(Version.SSSOM_1_0));
+        Assertions.assertTrue(Version.SSSOM_1_1.isCompatibleWith(Version.SSSOM_1_1));
+    }
+
+    @Test
+    void testGetHighestVersion() {
+        Assertions.assertEquals(Version.SSSOM_1_0, Version.getHighestVersion(Set.of(Version.SSSOM_1_0)));
+        Assertions.assertEquals(Version.SSSOM_1_1, Version.getHighestVersion(Set.of(Version.SSSOM_1_1)));
+        Assertions.assertEquals(Version.SSSOM_1_1,
+                Version.getHighestVersion(Set.of(Version.SSSOM_1_0, Version.SSSOM_1_1)));
+    }
+
+    @Test
+    void testUnknownVersion() {
+        Version unknown = Version.fromString("not a SSSOM version");
+        Assertions.assertEquals(Version.UNKNOWN, unknown);
+
+        // An unknown version cannot be compatible with any known version
+        Assertions.assertFalse(unknown.isCompatibleWith(Version.SSSOM_1_0));
+        Assertions.assertFalse(unknown.isCompatibleWith(Version.SSSOM_1_1));
+
+        // No known version can be compatible with an unknown version
+        Assertions.assertFalse(Version.SSSOM_1_0.isCompatibleWith(unknown));
+        Assertions.assertFalse(Version.SSSOM_1_1.isCompatibleWith(unknown));
+
+        // "Highest" version in a set containing an unknown version is unknown
+        Assertions.assertEquals(Version.UNKNOWN, Version.getHighestVersion(Set.of(unknown, Version.SSSOM_1_1)));
+    }
+}

--- a/core/src/test/resources/output/test-writing-sssom11-version.sssom.tsv
+++ b/core/src/test/resources/output/test-writing-sssom11-version.sssom.tsv
@@ -1,0 +1,9 @@
+#sssom_version: "1.1"
+#curie_map:
+#  COMENT: https://example.com/entities/
+#  ORGENT: https://example.org/entities/
+#mapping_set_id: https://example.org/sets/exo2c
+#license: https://creativecommons.org/licenses/by/4.0/
+#subject_type: composed entity expression
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification
+ORGENT:0001	alice	skos:closeMatch	COMENT:0011	alpha	semapv:ManualMappingCuration

--- a/core/src/test/resources/sets/test-invalid-version.sssom.tsv
+++ b/core/src/test/resources/sets/test-invalid-version.sssom.tsv
@@ -1,0 +1,9 @@
+#sssom_version: "something else"
+#curie_map:
+#  COMENT: https://example.com/entities/
+#  ORGENT: https://example.org/entities/
+#mapping_set_id: https://example.org/sets/exo2c
+#license: https://creativecommons.org/licenses/by/4.0/
+#subject_type: composed entity expression
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification
+ORGENT:0001	alice	skos:closeMatch	COMENT:0011	alpha	semapv:ManualMappingCuration

--- a/core/src/test/resources/sets/test-predicate-types.sssom.tsv
+++ b/core/src/test/resources/sets/test-predicate-types.sssom.tsv
@@ -1,3 +1,4 @@
+#sssom_version: "1.1"
 #curie_map:
 #  COMENT: https://example.com/entities/
 #  ORGENT: https://example.org/entities/

--- a/core/src/test/resources/sets/test-sssom10-with-version.sssom.tsv
+++ b/core/src/test/resources/sets/test-sssom10-with-version.sssom.tsv
@@ -1,0 +1,15 @@
+#sssom_version: "1.0"
+#curie_map:
+#  COMENT: https://example.com/entities/
+#  ORGENT: https://example.org/entities/
+#mapping_set_id: https://example.org/sets/test-sssom10-with-version
+#license: https://creativecommons.org/licenses/by/4.0/
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification
+ORGENT:0001	alice	skos:closeMatch	COMENT:0011	alpha	semapv:ManualMappingCuration
+ORGENT:0002	bob	skos:closeMatch	COMENT:0012	beta	semapv:ManualMappingCuration
+ORGENT:0004	daphne	skos:closeMatch	COMENT:0014	delta	semapv:ManualMappingCuration
+ORGENT:0005	eve	skos:closeMatch	COMENT:0015	epsilon	semapv:ManualMappingCuration
+ORGENT:0006	fanny	skos:closeMatch	COMENT:0016	zeta	semapv:ManualMappingCuration
+ORGENT:0007	gavin	skos:exactMatch	COMENT:0013	gamma	semapv:ManualMappingCuration
+ORGENT:0008	hector	skos:closeMatch	COMENT:0017	eta	semapv:ManualMappingCuration
+ORGENT:0009	ivan	skos:exactMatch	COMENT:0019	iota	semapv:ManualMappingCuration

--- a/core/src/test/resources/sets/test-sssom11-slots-with-no-version.sssom.tsv
+++ b/core/src/test/resources/sets/test-sssom11-slots-with-no-version.sssom.tsv
@@ -1,0 +1,14 @@
+#curie_map:
+#  COMENT: https://example.com/entities/
+#  ORGENT: https://example.org/entities/
+#mapping_set_id: https://example.org/sets/test-sssom11-slots-with-no-version
+#license: https://creativecommons.org/licenses/by/4.0/
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	predicate_type
+ORGENT:0001	alice	skos:closeMatch	COMENT:0011	alpha	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0002	bob	skos:closeMatch	COMENT:0012	beta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0004	daphne	skos:closeMatch	COMENT:0014	delta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0005	eve	skos:closeMatch	COMENT:0015	epsilon	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0006	fanny	skos:closeMatch	COMENT:0016	zeta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0007	gavin	skos:exactMatch	COMENT:0013	gamma	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0008	hector	skos:closeMatch	COMENT:0017	eta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0009	ivan	skos:exactMatch	COMENT:0019	iota	semapv:ManualMappingCuration	owl annotation property

--- a/core/src/test/resources/sets/test-sssom11-slots-with-version.sssom.tsv
+++ b/core/src/test/resources/sets/test-sssom11-slots-with-version.sssom.tsv
@@ -1,0 +1,15 @@
+#sssom_version: "1.1"
+#curie_map:
+#  COMENT: https://example.com/entities/
+#  ORGENT: https://example.org/entities/
+#mapping_set_id: https://example.org/sets/test-sssom11-slots-with-version
+#license: https://creativecommons.org/licenses/by/4.0/
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	predicate_type
+ORGENT:0001	alice	skos:closeMatch	COMENT:0011	alpha	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0002	bob	skos:closeMatch	COMENT:0012	beta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0004	daphne	skos:closeMatch	COMENT:0014	delta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0005	eve	skos:closeMatch	COMENT:0015	epsilon	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0006	fanny	skos:closeMatch	COMENT:0016	zeta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0007	gavin	skos:exactMatch	COMENT:0013	gamma	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0008	hector	skos:closeMatch	COMENT:0017	eta	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0009	ivan	skos:exactMatch	COMENT:0019	iota	semapv:ManualMappingCuration	owl annotation property

--- a/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/Constants.java
+++ b/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/Constants.java
@@ -39,6 +39,11 @@ public class Constants {
     public static final IRI SSSOM_MAPPINGS = Values.iri(SSSOM_NS, "mappings");
 
     /**
+     * The IRI of the property that links a SSSOM Version value to a mapping set.
+     */
+    public static final IRI SSSOM_VERSION = Values.iri(SSSOM_NS, "sssom_version");
+
+    /**
      * The IRI of the property that links a “Extension Definition” to the MappingSet
      * it belongs to.
      */

--- a/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFConverter.java
+++ b/ext/src/main/java/org/incenp/obofoundry/sssom/rdf/RDFConverter.java
@@ -46,6 +46,7 @@ import org.incenp.obofoundry.sssom.ExtensionSlotManager;
 import org.incenp.obofoundry.sssom.ExtraMetadataPolicy;
 import org.incenp.obofoundry.sssom.PrefixManager;
 import org.incenp.obofoundry.sssom.SSSOMFormatException;
+import org.incenp.obofoundry.sssom.Validator;
 import org.incenp.obofoundry.sssom.model.BuiltinPrefix;
 import org.incenp.obofoundry.sssom.model.EntityType;
 import org.incenp.obofoundry.sssom.model.ExtensionDefinition;
@@ -55,6 +56,7 @@ import org.incenp.obofoundry.sssom.model.MappingCardinality;
 import org.incenp.obofoundry.sssom.model.MappingSet;
 import org.incenp.obofoundry.sssom.model.PredicateModifier;
 import org.incenp.obofoundry.sssom.model.ValueType;
+import org.incenp.obofoundry.sssom.model.Version;
 import org.incenp.obofoundry.sssom.slots.DateSlot;
 import org.incenp.obofoundry.sssom.slots.DoubleSlot;
 import org.incenp.obofoundry.sssom.slots.EntityReferenceSlot;
@@ -68,6 +70,7 @@ import org.incenp.obofoundry.sssom.slots.SlotHelper;
 import org.incenp.obofoundry.sssom.slots.SlotVisitorBase;
 import org.incenp.obofoundry.sssom.slots.StringSlot;
 import org.incenp.obofoundry.sssom.slots.URISlot;
+import org.incenp.obofoundry.sssom.slots.VersionSlot;
 
 /**
  * A helper class to convert SSSOM objects to and from a RDF model in the Rdf4J
@@ -185,6 +188,9 @@ public class RDFConverter {
         bnodeCounter = 0;
         Set<String> usedPrefixes = prefixManager != null ? new HashSet<String>() : null;
 
+        // Determine mininum compliant version
+        ms.setSssomVersion(new Validator().getCompliantVersion(ms));
+
         // Create the mapping set node
         BNode set = Values.bnode(String.valueOf(bnodeCounter++));
         model.add(set, RDF.TYPE, Constants.SSSOM_MAPPING_SET);
@@ -245,14 +251,25 @@ public class RDFConverter {
         ms.setMappings(new ArrayList<Mapping>());
         SlotSetterVisitor<MappingSet> visitor = new SlotSetterVisitor<MappingSet>();
 
+        // Extract the SSSOM version first
+        Version version = versionFromRDF(model, set.get());
+        ms.setSssomVersion(version);
+        if ( version == Version.UNKNOWN ) {
+            version = Version.SSSOM_1_1;
+        }
+
         // Parse extension definitions ahead, so that definitions are available if/when
         // we encounter an extension slot when looping over all the statements
         extensionsFromRDF(ms, model, set.get());
 
         // Process all statements about the mapping set node
         for ( Statement st : model.filter(set.get(), null, null) ) {
+            if ( st.getPredicate().equals(Constants.SSSOM_VERSION) ) {
+                // We have dealt with that one already, skip
+                continue;
+            }
             Slot<MappingSet> slot = SlotHelper.getMappingSetHelper().getSlotByURI(st.getPredicate().stringValue());
-            if ( slot != null ) {
+            if ( slot != null && slot.getCompliantVersion().isCompatibleWith(version) ) {
                 // Statement is a mapping set metadata slot
                 visitor.rdfValue = st.getObject();
                 slot.accept(visitor, ms, null);
@@ -263,7 +280,7 @@ public class RDFConverter {
                 // Statement is an individual mapping
                 Value o = st.getObject();
                 if ( o instanceof BNode ) {
-                    ms.getMappings().add(mappingFromRDF(model.filter((BNode) o, null, null)));
+                    ms.getMappings().add(mappingFromRDF(model.filter((BNode) o, null, null), version));
                 } else {
                     throw getTypingError("mappings");
                 }
@@ -285,6 +302,9 @@ public class RDFConverter {
 
     /**
      * Converts a RDF model to a Mapping object.
+     * <p>
+     * This method assumes the mapping is compliant with the highest supported
+     * version of the specification.
      * 
      * @param model The Rdf4J model to convert.
      * @return The corresponding mapping.
@@ -292,6 +312,20 @@ public class RDFConverter {
      *                              is expected for a SSSOM Mapping object.
      */
     public Mapping mappingFromRDF(Model model) throws SSSOMFormatException {
+        return mappingFromRDF(model, Version.SSSOM_1_1);
+    }
+
+    /**
+     * Converts a RDF model to a Mapping object.
+     * 
+     * @param model         The Rdf4J model to convert.
+     * @param targetVersion The version of the SSSOM specification the mapping is
+     *                      compliant with.
+     * @return The corresponding mapping.
+     * @throws SSSOMFormatException If the contents of the model does not match what
+     *                              is expected for a SSSOM Mapping object.
+     */
+    public Mapping mappingFromRDF(Model model, Version targetVersion) throws SSSOMFormatException {
         Model root = model.filter(null, RDF.TYPE, Constants.OWL_AXIOM);
         Optional<BNode> mappingNode = Models.subjectBNode(root);
         if ( mappingNode.isEmpty() ) {
@@ -302,7 +336,7 @@ public class RDFConverter {
         SlotSetterVisitor<Mapping> visitor = new SlotSetterVisitor<Mapping>();
         for ( Statement st : model.filter(mappingNode.get(), null, null) ) {
             Slot<Mapping> slot = SlotHelper.getMappingHelper().getSlotByURI(st.getPredicate().stringValue());
-            if ( slot != null ) {
+            if ( slot != null && slot.getCompliantVersion().isCompatibleWith(targetVersion) ) {
                 // Statement is a mapping metadata slot
                 visitor.rdfValue = st.getObject();
                 slot.accept(visitor, mapping, null);
@@ -348,6 +382,21 @@ public class RDFConverter {
             helper.excludeSlots(excludedSlots);
         }
         return helper;
+    }
+
+    /*
+     * Extract the SSSOM Version value from the RDF model.
+     */
+    private Version versionFromRDF(Model model, BNode set) throws SSSOMFormatException {
+        Version version = Version.SSSOM_1_0;
+        for ( Statement st : model.filter(set, Constants.SSSOM_VERSION, null) ) {
+            if ( st.getObject().isLiteral() ) {
+                version = Version.fromString(st.getObject().stringValue());
+            } else {
+                throw getTypingError("sssom_version");
+            }
+        }
+        return version;
     }
 
     /*
@@ -794,6 +843,14 @@ public class RDFConverter {
                 }
 
                 model.add(subject, predicate, rdfValue);
+            }
+        }
+
+        @Override
+        public void visit(VersionSlot<T> slot, T object, Version value) {
+            if ( value != Version.SSSOM_1_0 && value != Version.UNKNOWN ) {
+                recordUsedIRI(slot.getURI());
+                model.add(subject, Values.iri(slot.getURI()), Values.literal(value.toString()));
             }
         }
     }

--- a/ext/src/test/java/org/incenp/obofoundry/sssom/rdf/RDFWriterTest.java
+++ b/ext/src/test/java/org/incenp/obofoundry/sssom/rdf/RDFWriterTest.java
@@ -49,6 +49,17 @@ public class RDFWriterTest {
     }
 
     @Test
+    void testWriteSSSOM11Version() {
+        MappingSet ms = getTestSet();
+        ms.getMappings().get(0).setPredicateType(EntityType.OWL_ANNOTATION_PROPERTY);
+        try {
+            assertWrittenAsExpected(ms, "test-sssom11-version", null, null);
+        } catch ( IOException e ) {
+            Assertions.fail(e);
+        }
+    }
+
+    @Test
     void testWriteShortIRIsWithEscapedCharacters() throws IOException {
         MappingSet ms = getTestSet();
         ms.getCreatorId().add("https://example.com/people/0000+0000?0002@5678");

--- a/ext/src/test/resources/sets/test-invalid-version.ttl
+++ b/ext/src/test/resources/sets/test-invalid-version.ttl
@@ -1,0 +1,42 @@
+@prefix COMENT: <https://example.com/entities/> .
+@prefix COMPID: <https://example.com/people/> .
+@prefix FBbt: <http://purl.obolibrary.org/obo/FBbt_> .
+@prefix ORGENT: <https://example.org/entities/> .
+@prefix ORGPID: <https://example.org/people/> .
+@prefix UBERON: <http://purl.obolibrary.org/obo/UBERON_> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix semapv: <https://w3id.org/semapv/vocab/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sssom: <https://w3id.org/sssom/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[] a sssom:MappingSet;
+  dcterms:creator COMPID:0000-0000-0002-5678, ORGPID:0000-0000-0001-1234;
+  dcterms:license "https://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI;
+  sssom:mapping_set_id "https://example.org/sets/exo2c"^^xsd:anyURI;
+  sssom:mappings [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource FBbt:12345678;
+      owl:annotatedTarget UBERON:1234567;
+      sssom:mapping_justification semapv:ManualMappingCuration
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0001;
+      owl:annotatedTarget COMENT:0011;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "alpha";
+      sssom:predicate_type owl:AnnotationProperty;
+      sssom:subject_label "alice";
+      sssom:subject_type owl:Class
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0002;
+      owl:annotatedTarget COMENT:0012;
+      sssom:confidence 7.0E-1;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "beta";
+      sssom:subject_label "bob";
+      sssom:subject_type owl:Class
+    ];
+  sssom:sssom_version sssom:version_1_1 .

--- a/ext/src/test/resources/sets/test-sssom10-version.ttl
+++ b/ext/src/test/resources/sets/test-sssom10-version.ttl
@@ -1,0 +1,41 @@
+@prefix COMENT: <https://example.com/entities/> .
+@prefix COMPID: <https://example.com/people/> .
+@prefix FBbt: <http://purl.obolibrary.org/obo/FBbt_> .
+@prefix ORGENT: <https://example.org/entities/> .
+@prefix ORGPID: <https://example.org/people/> .
+@prefix UBERON: <http://purl.obolibrary.org/obo/UBERON_> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix semapv: <https://w3id.org/semapv/vocab/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sssom: <https://w3id.org/sssom/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[] a sssom:MappingSet;
+  dcterms:creator COMPID:0000-0000-0002-5678, ORGPID:0000-0000-0001-1234;
+  dcterms:license "https://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI;
+  sssom:mapping_set_id "https://example.org/sets/exo2c"^^xsd:anyURI;
+  sssom:mappings [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource FBbt:12345678;
+      owl:annotatedTarget UBERON:1234567;
+      sssom:mapping_justification semapv:ManualMappingCuration
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0001;
+      owl:annotatedTarget COMENT:0011;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "alpha";
+      sssom:subject_label "alice";
+      sssom:subject_type owl:Class
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0002;
+      owl:annotatedTarget COMENT:0012;
+      sssom:confidence 7.0E-1;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "beta";
+      sssom:subject_label "bob";
+      sssom:subject_type owl:Class
+    ];
+  sssom:sssom_version "1.0" .

--- a/ext/src/test/resources/sets/test-sssom11-version.ttl
+++ b/ext/src/test/resources/sets/test-sssom11-version.ttl
@@ -1,0 +1,42 @@
+@prefix COMENT: <https://example.com/entities/> .
+@prefix COMPID: <https://example.com/people/> .
+@prefix FBbt: <http://purl.obolibrary.org/obo/FBbt_> .
+@prefix ORGENT: <https://example.org/entities/> .
+@prefix ORGPID: <https://example.org/people/> .
+@prefix UBERON: <http://purl.obolibrary.org/obo/UBERON_> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix semapv: <https://w3id.org/semapv/vocab/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sssom: <https://w3id.org/sssom/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[] a sssom:MappingSet;
+  dcterms:creator COMPID:0000-0000-0002-5678, ORGPID:0000-0000-0001-1234;
+  dcterms:license "https://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI;
+  sssom:mapping_set_id "https://example.org/sets/exo2c"^^xsd:anyURI;
+  sssom:mappings [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource FBbt:12345678;
+      owl:annotatedTarget UBERON:1234567;
+      sssom:mapping_justification semapv:ManualMappingCuration
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0001;
+      owl:annotatedTarget COMENT:0011;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "alpha";
+      sssom:predicate_type owl:AnnotationProperty;
+      sssom:subject_label "alice";
+      sssom:subject_type owl:Class
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0002;
+      owl:annotatedTarget COMENT:0012;
+      sssom:confidence 7.0E-1;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "beta";
+      sssom:subject_label "bob";
+      sssom:subject_type owl:Class
+    ];
+  sssom:sssom_version "1.1" .

--- a/ext/src/test/resources/sets/test-unknown-version.ttl
+++ b/ext/src/test/resources/sets/test-unknown-version.ttl
@@ -1,0 +1,42 @@
+@prefix COMENT: <https://example.com/entities/> .
+@prefix COMPID: <https://example.com/people/> .
+@prefix FBbt: <http://purl.obolibrary.org/obo/FBbt_> .
+@prefix ORGENT: <https://example.org/entities/> .
+@prefix ORGPID: <https://example.org/people/> .
+@prefix UBERON: <http://purl.obolibrary.org/obo/UBERON_> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix semapv: <https://w3id.org/semapv/vocab/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sssom: <https://w3id.org/sssom/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[] a sssom:MappingSet;
+  dcterms:creator COMPID:0000-0000-0002-5678, ORGPID:0000-0000-0001-1234;
+  dcterms:license "https://creativecommons.org/licenses/by/4.0/"^^xsd:anyURI;
+  sssom:mapping_set_id "https://example.org/sets/exo2c"^^xsd:anyURI;
+  sssom:mappings [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource FBbt:12345678;
+      owl:annotatedTarget UBERON:1234567;
+      sssom:mapping_justification semapv:ManualMappingCuration
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0001;
+      owl:annotatedTarget COMENT:0011;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "alpha";
+      sssom:predicate_type owl:AnnotationProperty;
+      sssom:subject_label "alice";
+      sssom:subject_type owl:Class
+    ], [ a owl:Axiom;
+      owl:annotatedProperty skos:closeMatch;
+      owl:annotatedSource ORGENT:0002;
+      owl:annotatedTarget COMENT:0012;
+      sssom:confidence 7.0E-1;
+      sssom:mapping_justification semapv:ManualMappingCuration;
+      sssom:object_label "beta";
+      sssom:subject_label "bob";
+      sssom:subject_type owl:Class
+    ];
+  sssom:sssom_version "not a SSSOM version" .


### PR DESCRIPTION
This PR adds support for the newly proposed `sssom_version` slot in the SSSOM specification.

It updates all SSSOM parsers (TSV/CSV, JSON, Turtle) to make them recognise the `sssom_version` slot and enable/disable the recognition of post-1.0 slots accordingly (i.e. a slot added in SSSOM 1.1, such as `predicate_type`, would not be recognised in a 1.0-compliant set – it would be treated as an _extension slot_).

It updates all SSSOM writers (TSV/CSV, JSON, Turtle) to make them emit the `sssom_version` slot as needed (if a set requires a post-1.0 version).

/!\ Not to be merged until/unless the [`sssom_slot` proposition in the SSSOM spec](https://github.com/mapping-commons/sssom/pull/440) has been accepted.